### PR TITLE
Optimize forward step for large populations

### DIFF
--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -363,8 +363,8 @@ def comb2_reduced(l: np.array, idx: list) -> tuple:
 def n_choose_k(n: int, k: int) -> int:
     """
     Calulate the number of combinations in N choose K. 
-    When k is 0 or 1, the answer is returned directly. When k > 1, iterate to compute factoral to compute 
-    nCr formula = n! / (r! (n-r)! by using m as an accumulator
+    When K is 0 or 1, the answer is returned directly. When K > 1, iterate to compute factoral to compute 
+    nCk formula = n! / (k! (n-k)! by using m as an accumulator
     """
     m = 0
     if k == 0:

--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -110,7 +110,7 @@ class PandemicSim:
             possible_contacts_y = []
             num_possible_contacts = 0
 
-            num_possible_contacts = nCk(len(grp1), 2) if grp1 == grp2 else len(grp1) * len(grp2)
+            num_possible_contacts = n_choose_k(len(grp1), 2) if grp1 == grp2 else len(grp1) * len(grp2)
 
             if num_possible_contacts == 0:
                 continue
@@ -349,16 +349,22 @@ def prod_reduced(a: np.array, b: np.array, idx: list) -> tuple:
 
 def comb2_reduced(l: np.array, idx: list) -> tuple:
     """
-    return combinations of 2 only at desired indices
+    Compute combinations of 2 on a subarray of input l given by indicies in input idx
+    Uses the upper triangular matrix on input l to generate 2-combination coordinates which are extracted from l as a vector
+    input: 
+     (vector) l - base array
+     (vector) idx - index values of l that define a subvector for which combinations of 2 will be computed
     """
     triu = np.triu_indices(l.size, 1)
     return l[triu[0][idx]], l[triu[1][idx]]
 
 
 @lru_cache(maxsize=None)
-def nCk(n: int, k: int) -> int:
+def n_choose_k(n: int, k: int) -> int:
     """
-    calulate binomial coeffecients
+    Calulate the number of combinations in N choose K. 
+    When k is 0 or 1, the answer is returned directly. When k > 1, iterate to compute factoral to compute 
+    nCr formula = n! / (r! (n-r)! by using m as an accumulator
     """
     m = 0
     if k == 0:

--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -115,15 +115,11 @@ class PandemicSim:
             if num_possible_contacts == 0:
                 continue
             
-
             fraction_sample = min(1., max(0., self._numpy_rng.normal(fraction, 1e-2)))
             real_fraction = max(minimum, int(fraction_sample * num_possible_contacts))
             # we are using an orderedset, it's repeatable
             contact_idx = self._numpy_rng.randint(0, num_possible_contacts, real_fraction)
 
-            #if real_fraction > num_possible_contacts: real_fraction = num_possible_contacts
-            #contact_idx = self._numpy_rng.choice(num_possible_contacts, real_fraction, replace=False)
-            
             if grp1 == grp2:
                 possible_contacts_x, possible_contacts_y = comb2_reduced(np.asarray(grp1),contact_idx)
             else:

--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -99,8 +99,8 @@ class PandemicSim:
                        (cr.min_assignees_visitors, cr.fraction_assignees_visitors),
                        (cr.min_visitors, cr.fraction_visitors)]
 
-        contacts_x : List = list()
-        contacts_y : List = list()
+        contacts_x: List = list()
+        contacts_y: List = list()
         for grp, cst in zip(groups, constraints):
             grp1, grp2 = grp
             minimum, fraction = cst
@@ -128,15 +128,15 @@ class PandemicSim:
 
         # Stuff the contact pairs into a dictionary/Set, removing duplicates from repeats in contact_idx
         r = dict()
-        for i,c in enumerate(contacts_x):
+        for i, c in enumerate(contacts_x):
             r[contacts_x[i], contacts_y[i]] = 0
         return r
 
     def _compute_infection_probabilities(self, contacts: dict) -> None:
-        if len(contacts) < 1: 
+        if len(contacts) < 1:
             return
         infectious_states = {InfectionSummary.INFECTED, InfectionSummary.CRITICAL}
-        
+
         for c in contacts:
             id_person1 = c[0]
             id_person2 = c[1]
@@ -320,7 +320,7 @@ class PandemicSim:
 
     def person_update(self, person: Person) -> None:
         person.step(self._state.sim_time, self._contact_tracer)
-
+        return
 
 def prod_reduced(a: np.array, b: np.array, idx: list) -> tuple:
     """
@@ -336,13 +336,11 @@ def comb2_reduced(l: np.array, idx: list) -> tuple:
     triu = np.triu_indices(l.size, 1)
     return l[triu[0][idx]], l[triu[1][idx]]
 
-
 @lru_cache(maxsize=None)
-def nCk(n, k) -> int:
+def nCk(n: int, k: int) -> int:
     """
     calulate binomial coeffecients
     """
-
     m = 0
     if k == 0:
         m = 1

--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -1,6 +1,6 @@
 # Confidential, Copyright 2020, Sony Corporation of America, All rights reserved.
 
-from collections import defaultdict, deque
+from collections import defaultdict
 from typing import DefaultDict, Dict, List, Optional, Sequence, cast
 from functools import lru_cache
 
@@ -201,7 +201,8 @@ class PandemicSim:
         self._registry.update_location_specific_information()
 
         # call person steps
-        deque([self.person_update(p) for p in self._id_to_person.values()])
+        for person in self._id_to_person.values():
+            person.step(self._state.sim_time, self._contact_tracer)
 
         # update person contacts
         for location in self._id_to_location.values():
@@ -317,10 +318,10 @@ class PandemicSim:
             infection_above_threshold=False,
         )
 
-
     def person_update(self, person: Person) -> None:
         person.step(self._state.sim_time, self._contact_tracer)
         return
+
 
 def prod_reduced(a: np.array, b: np.array, idx: list) -> tuple:
     """
@@ -335,6 +336,7 @@ def comb2_reduced(l: np.array, idx: list) -> tuple:
     """
     triu = np.triu_indices(l.size, 1)
     return l[triu[0][idx]], l[triu[1][idx]]
+
 
 @lru_cache(maxsize=None)
 def nCk(n: int, k: int) -> int:

--- a/python/pandemic_simulator/environment/pandemic_sim.py
+++ b/python/pandemic_simulator/environment/pandemic_sim.py
@@ -350,10 +350,12 @@ def prod_reduced(a: np.array, b: np.array, idx: list) -> tuple:
 def comb2_reduced(l: np.array, idx: list) -> tuple:
     """
     Compute combinations of 2 on a subarray of input l given by indicies in input idx
-    Uses the upper triangular matrix on input l to generate 2-combination coordinates which are extracted from l as a vector
-    input: 
-     (vector) l - base array
-     (vector) idx - index values of l that define a subvector for which combinations of 2 will be computed
+    Uses the upper triangular matrix on input l to generate 2-combination coordinates which are extracted from
+    l as a vector
+
+    :param: l, base array
+    :param: idx, index values of l that define a subvector for which combinations of 2 will be computed
+    :return: actual combinations of 2 in l given idx
     """
     triu = np.triu_indices(l.size, 1)
     return l[triu[0][idx]], l[triu[1][idx]]
@@ -362,9 +364,11 @@ def comb2_reduced(l: np.array, idx: list) -> tuple:
 @lru_cache(maxsize=None)
 def n_choose_k(n: int, k: int) -> int:
     """
-    Calulate the number of combinations in N choose K. 
-    When K is 0 or 1, the answer is returned directly. When K > 1, iterate to compute factoral to compute 
+    Calulate the number of combinations in N choose K
+    When K is 0 or 1, the answer is returned directly. When K > 1, iterate to compute factoral to compute
     nCk formula = n! / (k! (n-k)! by using m as an accumulator
+
+    :return: number of ways to choose k from n
     """
     m = 0
     if k == 0:


### PR DESCRIPTION
This introduces optimizations in the simulator's forward step that reduces the iteration time for sufficiently large populations. This is  accomplished through 

1. limiting the computation of `combination` and `product` used for computing contact pairs to only the randomized indices that are relevant
2. transparent changes to some data structures (like using `dict` rather than `orderedSets` where possible)

Based on experiments, the execution time of running the simulator at the current `main` branch vs  these changes are as follows:
```
Population                main         this PR
1000                      56.0s        58.0s
2000                      2:10m        2:12m
4000                      4:15m        4:13m
10000                    ~22.0m       12:32m
100000                 3:40:05hr     2:26:43hr
```
Testing can be done by running `scripts/run_pandemic_sim.py`