### PR TITLE
Updated PersonRoutine to support state based start triggers

### DIFF
--- a/python/pandemic_simulator/environment/interfaces/location_base_business.py
+++ b/python/pandemic_simulator/environment/interfaces/location_base_business.py
@@ -21,6 +21,10 @@ class BusinessBaseLocation(BaseLocation[_BusinessState], metaclass=ABCMeta):
 
     location_rule_type: Type = BusinessLocationRule
 
+    def sync(self, sim_time: SimTime) -> None:
+        super().sync(sim_time)
+        self._state.is_open = sim_time in self._state.open_time
+
     def update_rules(self, new_rule: LocationRule) -> None:
         super().update_rules(new_rule)
         rule = cast(BusinessLocationRule, new_rule)

--- a/python/pandemic_simulator/environment/interfaces/person_routine.py
+++ b/python/pandemic_simulator/environment/interfaces/person_routine.py
@@ -20,13 +20,13 @@ class SpecialEndLoc(enum.Enum):
 class RoutineTrigger(metaclass=ABCMeta):
 
     @abstractmethod
-    def trigger(self, sim_time: SimTime, person_state: PersonState) -> bool:
+    def trigger(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> bool:
         pass
 
 
 class SimTimeRoutineTrigger(RoutineTrigger, SimTimeInterval):
 
-    def trigger(self, sim_time: SimTime, person_state: PersonState) -> bool:
+    def trigger(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> bool:
         return self.trigger_at_interval(sim_time)
 
 
@@ -61,7 +61,7 @@ class PersonRoutine:
     duration_of_stay_at_end_loc: int = 1
     """Specifies the duration (in hours) to stay at the end location."""
 
-    reset_when_done: RoutineTrigger = SimTimeRoutineTrigger(day=1)
+    reset_when_done_trigger: RoutineTrigger = SimTimeRoutineTrigger(day=1)
     """Specifies a trigger to reset the routine when completed"""
 
 
@@ -77,17 +77,17 @@ class PersonRoutineWithStatus:
     end_loc_selected: Optional[LocationID] = None
     """The final end_loc selected after sampling from routine.explorable_end_locs"""
 
-    def _is_routine_due(self, sim_time: SimTime, person_state: PersonState) -> bool:
+    def _is_routine_due(self, sim_time: SimTime, person_state: Optional[PersonState]) -> bool:
         if self.started or self.done or sim_time not in self.routine.valid_time:
             # not due if the routine has already started or is completed or is not valid
             return False
 
         return self.due or self.routine.start_trigger.trigger(sim_time, person_state)
 
-    def sync(self, sim_time: SimTime, person_state: PersonState) -> None:
+    def sync(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> None:
         """Sync the status variables with time."""
         # if completed check if you need to reset the routine for a repetition
-        if self.done and self.routine.reset_when_done.trigger(sim_time, person_state):
+        if self.done and self.routine.reset_when_done_trigger.trigger(sim_time, person_state):
             self.reset()
 
         self.due = self._is_routine_due(sim_time, person_state)

--- a/python/pandemic_simulator/environment/interfaces/person_routine.py
+++ b/python/pandemic_simulator/environment/interfaces/person_routine.py
@@ -20,13 +20,13 @@ class SpecialEndLoc(enum.Enum):
 class RoutineTrigger(metaclass=ABCMeta):
 
     @abstractmethod
-    def trigger(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> bool:
+    def trigger(self, sim_time: SimTime, person_state: PersonState) -> bool:
         pass
 
 
 class SimTimeRoutineTrigger(RoutineTrigger, SimTimeInterval):
 
-    def trigger(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> bool:
+    def trigger(self, sim_time: SimTime, person_state: PersonState) -> bool:
         return self.trigger_at_interval(sim_time)
 
 
@@ -77,20 +77,20 @@ class PersonRoutineWithStatus:
     end_loc_selected: Optional[LocationID] = None
     """The final end_loc selected after sampling from routine.explorable_end_locs"""
 
-    def _is_routine_due(self, sim_time: SimTime) -> bool:
+    def _is_routine_due(self, sim_time: SimTime, person_state: PersonState) -> bool:
         if self.started or self.done or sim_time not in self.routine.valid_time:
             # not due if the routine has already started or is completed or is not valid
             return False
 
-        return self.due or self.routine.start_trigger.trigger(sim_time)
+        return self.due or self.routine.start_trigger.trigger(sim_time, person_state)
 
-    def sync(self, sim_time: SimTime) -> None:
+    def sync(self, sim_time: SimTime, person_state: PersonState) -> None:
         """Sync the status variables with time."""
         # if completed check if you need to reset the routine for a repetition
-        if self.done and self.routine.reset_when_done.trigger(sim_time):
+        if self.done and self.routine.reset_when_done.trigger(sim_time, person_state):
             self.reset()
 
-        self.due = self._is_routine_due(sim_time)
+        self.due = self._is_routine_due(sim_time, person_state)
 
     def reset(self) -> None:
         """Reset status variables"""

--- a/python/pandemic_simulator/environment/interfaces/sim_time.py
+++ b/python/pandemic_simulator/environment/interfaces/sim_time.py
@@ -70,13 +70,14 @@ class SimTimeInterval:
     def __post_init__(self) -> None:
         assert self.hour in range(24), 'Set a value in [1, 23] for an interval in hours'
         assert self.day in range(365), 'Set a value in [1, 365] for an interval in days'
+        assert self.hour + self.day + self.year > 0, 'Provide a non-zero value at least for either of hour/day/year'
         object.__setattr__(self, '_trigger_hr', self.in_hours())
         object.__setattr__(self, '_offset_hr', self.offset_day * 24 + self.offset_hour)
 
     def trigger_at_interval(self, sim_time: SimTime) -> bool:
         """Return True at sim time interval and False otherwise."""
         sim_hr = sim_time.year * 365 * 24 + sim_time.day * 24 + sim_time.hour
-        return max(sim_hr - self._offset_hr, 0) % self._trigger_hr == 0
+        return (sim_hr - self._offset_hr) % self._trigger_hr == 0 if sim_hr >= self._offset_hr else False
 
     def in_hours(self) -> int:
         return self.year * 365 * 24 + self.day * 24 + self.hour

--- a/python/pandemic_simulator/environment/person/minor.py
+++ b/python/pandemic_simulator/environment/person/minor.py
@@ -71,7 +71,7 @@ class Minor(BasePerson):
         super()._sync(sim_time)
 
         for rws in self._outside_school_rs:
-            rws.sync(sim_time)
+            rws.sync(sim_time=sim_time, person_state=self.state)
 
     def step(self, sim_time: SimTime, contact_tracer: Optional[ContactTracer] = None) -> Optional[NoOP]:
         step_ret = super().step(sim_time, contact_tracer)

--- a/python/pandemic_simulator/environment/person/retired.py
+++ b/python/pandemic_simulator/environment/person/retired.py
@@ -39,7 +39,7 @@ class Retired(BasePerson):
         super()._sync(sim_time)
 
         for rws in self._routines_with_status:
-            rws.sync(sim_time)
+            rws.sync(sim_time=sim_time, person_state=self.state)
 
     def set_routines(self, routines: Sequence[PersonRoutine]) -> None:
         """A sequence of person routines to execute"""

--- a/python/pandemic_simulator/environment/person/routine_utils.py
+++ b/python/pandemic_simulator/environment/person/routine_utils.py
@@ -3,7 +3,7 @@ from typing import Sequence, Optional, cast, Type, Tuple
 
 from .base import BasePerson
 from ..interfaces import PersonRoutineWithStatus, NoOP, NOOP, LocationID, SpecialEndLoc, globals, PersonRoutine, \
-    SimTimeInterval, SimTimeTuple
+    SimTimeTuple, SimTimeRoutineTrigger, RoutineTrigger
 
 __all__ = ['execute_routines', 'triggered_routine', 'weekend_routine', 'mid_day_during_week_routine', 'social_routine']
 
@@ -86,8 +86,8 @@ def triggered_routine(start_loc: Optional[LocationID],
     end_loc, explorable_end_locs = _get_locations_from_type(end_location_type)
     return PersonRoutine(start_loc=start_loc,
                          end_loc=end_loc,
-                         start_trigger_time=SimTimeInterval(day=interval_in_days,
-                                                            offset_day=globals.numpy_rng.randint(0, interval_in_days)),
+                         start_trigger=SimTimeRoutineTrigger(day=interval_in_days,
+                                                             offset_day=globals.numpy_rng.randint(0, interval_in_days)),
                          explorable_end_locs=explorable_end_locs,
                          explore_probability=explore_probability)
 
@@ -95,14 +95,14 @@ def triggered_routine(start_loc: Optional[LocationID],
 def weekend_routine(start_loc: Optional[LocationID],
                     end_location_type: type,
                     explore_probability: float = 0.05,
-                    repeat_interval_when_done: SimTimeInterval = SimTimeInterval(day=1)) -> PersonRoutine:
+                    reset_when_done: RoutineTrigger = SimTimeRoutineTrigger(day=1)) -> PersonRoutine:
     end_loc, explorable_end_locs = _get_locations_from_type(end_location_type)
     return PersonRoutine(start_loc=start_loc,
                          end_loc=end_loc,
                          valid_time=SimTimeTuple(week_days=(5, 6)),
                          explorable_end_locs=explorable_end_locs,
                          explore_probability=explore_probability,
-                         repeat_interval_when_done=repeat_interval_when_done)
+                         reset_when_done=reset_when_done)
 
 
 def mid_day_during_week_routine(start_loc: Optional[LocationID],
@@ -121,4 +121,4 @@ def social_routine(start_loc: Optional[LocationID]) -> PersonRoutine:
                          end_loc=SpecialEndLoc.social,
                          valid_time=SimTimeTuple(hours=tuple(range(15, 20))),
                          duration_of_stay_at_end_loc=globals.numpy_rng.randint(1, 3),
-                         repeat_interval_when_done=SimTimeInterval(day=7))
+                         reset_when_done=SimTimeRoutineTrigger(day=7))

--- a/python/pandemic_simulator/environment/person/routine_utils.py
+++ b/python/pandemic_simulator/environment/person/routine_utils.py
@@ -102,7 +102,7 @@ def weekend_routine(start_loc: Optional[LocationID],
                          valid_time=SimTimeTuple(week_days=(5, 6)),
                          explorable_end_locs=explorable_end_locs,
                          explore_probability=explore_probability,
-                         reset_when_done=reset_when_done)
+                         reset_when_done_trigger=reset_when_done)
 
 
 def mid_day_during_week_routine(start_loc: Optional[LocationID],
@@ -121,4 +121,4 @@ def social_routine(start_loc: Optional[LocationID]) -> PersonRoutine:
                          end_loc=SpecialEndLoc.social,
                          valid_time=SimTimeTuple(hours=tuple(range(15, 20))),
                          duration_of_stay_at_end_loc=globals.numpy_rng.randint(1, 3),
-                         reset_when_done=SimTimeRoutineTrigger(day=7))
+                         reset_when_done_trigger=SimTimeRoutineTrigger(day=7))

--- a/python/pandemic_simulator/environment/person/worker.py
+++ b/python/pandemic_simulator/environment/person/worker.py
@@ -78,7 +78,7 @@ class Worker(BasePerson):
         super()._sync(sim_time)
 
         for rws in self._during_work_rs + self._outside_work_rs:
-            rws.sync(sim_time)
+            rws.sync(sim_time=sim_time, person_state=self.state)
 
     def step(self, sim_time: SimTime, contact_tracer: Optional[ContactTracer] = None) -> Optional[NoOP]:
         step_ret = super().step(sim_time, contact_tracer)

--- a/scripts/tutorials/2_simple_worker_loop_with_routines.py
+++ b/scripts/tutorials/2_simple_worker_loop_with_routines.py
@@ -58,9 +58,9 @@ def simple_worker_loop_with_routines() -> None:
 
             end_loc=store.id,  # store id
 
-            start_trigger_time=ps.env.SimTimeInterval(day=7),
-            # notice that we set here start_trigger_time argument instead of valid_time. start_trigger_time specifies
-            # the interval that triggers the start of the routine. In this case, the routine is triggered every
+            start_trigger=ps.env.SimTimeRoutineTrigger(day=7),
+            # notice that we set here start_trigger argument instead of valid_time. start_trigger specifies
+            # a trigger to enable the routine. In this case, the routine is triggered every
             # seventh day. Once triggered, it is queued to be executed until it gets triggered again.
         )
 

--- a/scripts/tutorials/2_simple_worker_loop_with_routines.py
+++ b/scripts/tutorials/2_simple_worker_loop_with_routines.py
@@ -62,6 +62,9 @@ def simple_worker_loop_with_routines() -> None:
             # notice that we set here start_trigger argument instead of valid_time. start_trigger specifies
             # a trigger to enable the routine. In this case, the routine is triggered every
             # seventh day. Once triggered, it is queued to be executed until it gets triggered again.
+            # Advanced tip: SimTimeRoutineTrigger triggers based on sim_time only. If you want to create state
+            # based triggers, you can implement it similar to SimTimeRoutineTrigger and use person_state to return
+            # a boolean.
         )
 
     ]

--- a/scripts/tutorials/2_simple_worker_loop_with_routines.py
+++ b/scripts/tutorials/2_simple_worker_loop_with_routines.py
@@ -64,7 +64,7 @@ def simple_worker_loop_with_routines() -> None:
             # seventh day. Once triggered, it is queued to be executed until it gets triggered again.
             # Advanced tip: SimTimeRoutineTrigger triggers based on sim_time only. If you want to create state
             # based triggers, you can implement it similar to SimTimeRoutineTrigger and use person_state to return
-            # a boolean.
+            # a boolean (see test/environment/test_person_routines.py for an example).
         )
 
     ]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'istype>=0.2.0',
         'matplotlib',
         'networkx',  # for graph analysis
-        'numpy',
+        'numpy==1.19.5',    # 1.20 numpy requires mypy fixes #TODO
         'scipy',
         'probabilistic-automata>=0.4.0',  # for probabilistic DFA
         'pyrsistent>=0.15.5',  # for frozen classes

--- a/test/environment/test_person_routines.py
+++ b/test/environment/test_person_routines.py
@@ -1,0 +1,98 @@
+# Confidential, Copyright 2021, Sony Corporation of America, All rights reserved.
+from typing import Optional
+
+import pandemic_simulator as ps
+from pandemic_simulator.environment import SimTime, PersonState
+
+
+def test_person_routine_with_status_sim_time_trigger() -> None:
+    ps.init_globals()
+
+    home = ps.env.Home()
+    store = ps.env.GroceryStore()
+
+    r = ps.env.PersonRoutine(start_loc=home.id,
+                             end_loc=store.id,
+                             start_trigger=ps.env.SimTimeRoutineTrigger(day=1, offset_hour=10),
+                             reset_when_done_trigger=ps.env.SimTimeRoutineTrigger(day=1, offset_hour=14))
+    rws = ps.env.PersonRoutineWithStatus(r)
+
+    # at start all flags are false
+    rws.sync(ps.env.SimTime(hour=0))
+    assert not rws.started
+    assert not rws.due
+    assert not rws.done
+
+    # due should be true at trigger
+    rws.sync(ps.env.SimTime(hour=10))
+    assert rws.due
+
+    # due should remain true even after trigger
+    rws.sync(ps.env.SimTime(hour=11))
+    assert rws.due
+
+    # due should switch to false when routine has started
+    rws.started = True
+    rws.sync(ps.env.SimTime(hour=12))
+    assert not rws.due
+
+    # same when done is True
+    rws.done = True
+    rws.sync(ps.env.SimTime(hour=13))
+    assert not rws.due
+
+    # flags reset at reset trigger
+    rws.sync(ps.env.SimTime(hour=14))
+    assert not rws.started
+    assert not rws.due
+    assert not rws.done
+
+
+class StateRoutineTrigger(ps.env.RoutineTrigger):
+
+    def trigger(self, sim_time: SimTime, person_state: Optional[PersonState] = None) -> bool:
+        assert person_state
+        return person_state.risk == ps.env.Risk.HIGH
+
+
+def test_person_routine_with_status_state_trigger() -> None:
+    ps.init_globals()
+
+    home = ps.env.Home()
+    store = ps.env.GroceryStore()
+
+    r = ps.env.PersonRoutine(start_loc=home.id,
+                             end_loc=store.id,
+                             start_trigger=StateRoutineTrigger(),
+                             reset_when_done_trigger=ps.env.SimTimeRoutineTrigger(day=1))
+    rws = ps.env.PersonRoutineWithStatus(r)
+
+    # check flags for non-trigger state
+    rws.sync(ps.env.SimTime(hour=5), person_state=PersonState(home.id, risk=ps.env.Risk.LOW))
+    assert not rws.started
+    assert not rws.due
+    assert not rws.done
+
+    # due should be true at state trigger
+    rws.sync(ps.env.SimTime(hour=5), person_state=PersonState(home.id, risk=ps.env.Risk.HIGH))
+    assert rws.due
+
+    # due should remain true even after trigger
+    rws.sync(ps.env.SimTime(hour=11), person_state=PersonState(home.id, risk=ps.env.Risk.LOW))
+    assert rws.due
+
+    # due should switch to false when routine has started
+    rws.started = True
+    rws.sync(ps.env.SimTime(hour=12), person_state=PersonState(home.id, risk=ps.env.Risk.HIGH))
+    assert not rws.due
+
+    # same when done is True
+    rws.done = True
+    rws.sync(ps.env.SimTime(hour=13), person_state=PersonState(home.id, risk=ps.env.Risk.HIGH))
+    assert not rws.due
+
+    # flags reset at reset trigger and due is again set (because of state trigger)
+    rws.sync(ps.env.SimTime(day=1, hour=0), person_state=PersonState(home.id, risk=ps.env.Risk.HIGH))
+    assert not rws.started
+    assert rws.due
+    assert not rws.done

--- a/test/environment/test_sim_time_interval.py
+++ b/test/environment/test_sim_time_interval.py
@@ -1,5 +1,7 @@
 # Confidential, Copyright 2020, Sony Corporation of America, All rights reserved.
 
+import pytest
+
 from pandemic_simulator.environment import SimTime, SimTimeInterval
 
 
@@ -23,16 +25,25 @@ def test_sim_time_interval_trigger_day() -> None:
         assert not interval.trigger_at_interval(SimTime(day=day, hour=1))
 
 
-def test_sim_time_interval_trigger_offset() -> None:
-    offset_hour = 2
-    offset_day = 1
-    hour = 1
-    day = 3
-
+@pytest.mark.parametrize(['hour', 'day', 'offset_hour', 'offset_day'],
+                         [
+                             [1, 3, 2, 1],
+                             [0, 1, 5, 0],
+                             [2, 0, 1, 0],
+                             [0, 2, 0, 1]
+                         ]
+                         )
+def test_sim_time_interval_trigger_offset(hour: int, day: int, offset_hour: int, offset_day: int) -> None:
     interval = SimTimeInterval(hour=hour, day=day, offset_hour=offset_hour, offset_day=offset_day)
+
+    if offset_day > 0:
+        for i in range(offset_day + 1):
+            for j in range(24 if i < offset_day else offset_hour):
+                assert not interval.trigger_at_interval(SimTime(day=day, hour=i))
+    else:
+        for i in range(offset_hour):
+            assert not interval.trigger_at_interval(SimTime(hour=i))
+
     for i in range(1, 3):
         assert interval.trigger_at_interval(SimTime(day=day * i + offset_day, hour=hour * i + offset_hour))
         assert not interval.trigger_at_interval(SimTime(day=day * i, hour=hour * i))
-        assert not interval.trigger_at_interval(SimTime(day=day * i + 1))
-        assert not interval.trigger_at_interval(SimTime(day=day * i - 1))
-        assert not interval.trigger_at_interval(SimTime(day=day, hour=1))


### PR DESCRIPTION
Previously, start trigger in PersonRoutine only used SimTime to decide when to activate a routine. This PR extends the functionality to also use person's state variables to trigger a start and reset for a routine. 
This PR also fixes a minor sim_time trigger bug.

Testing:
Auto (PR includes unittests and a regression test for the bug)